### PR TITLE
fix/backend-deploy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,11 +16,10 @@ services:
     build:
       context: ./frontend
       args:
-        # ビルド時に API を埋め込む（env から受け取る）。未設定なら backend を参照
-        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://backend:8080}
+        # プロキシ方式: クライアントは /api を叩く
+        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-/api}
     environment:
-      # ランタイムで上書きしたい場合に使用（未設定ならビルド時の値が使われます）
-      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-http://backend:8080}
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL:-/api}
       PORT: "3000"
     ports:
       - "3000:3000"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,8 +10,8 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# API エンドポイントはビルド時に埋め込む（ランタイムでも上書き可）
-ARG NEXT_PUBLIC_API_BASE_URL="http://localhost:8080"
+# APIベースURLは /api に固定（Vercel リバースプロキシ使用）
+ARG NEXT_PUBLIC_API_BASE_URL="/api"
 ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
 
 RUN --mount=type=cache,target=/root/.npm \

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,13 +1,13 @@
 import type { NextConfig } from "next";
 
-// Proxy Next.js API requests to Go backend to keep UI unchanged
+// Proxy /api/* -> BACKEND_ORIGIN/*
 const nextConfig: NextConfig = {
   async rewrites() {
-    const backendUrl = process.env.BACKEND_URL || "http://localhost:8080";
+    const backendOrigin = process.env.BACKEND_ORIGIN || "http://backend:8080";
     return [
       {
         source: "/api/:path*",
-        destination: `${backendUrl}/api/:path*`,
+        destination: `${backendOrigin}/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## 💻概要
### 機能名
backendのデプロイURLを修正

### 📸スクリーンショット

## 📄修正内容
RailwayのURLからVercelのURLに修正。
```https://bini-challenge.vercel.app/api/```にバックエンドデータが公開
## 👀動作確認

## ❌現存エラー

## 📝補足

## 📄参考資料
